### PR TITLE
Add control for elapsed time

### DIFF
--- a/controls.gemspec
+++ b/controls.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name = 'controls'
-  s.version = '0.0.2.0'
+  s.version = '0.0.3.0'
   s.summary = 'Test controls'
   s.description = ' '
 

--- a/lib/controls.rb
+++ b/lib/controls.rb
@@ -6,4 +6,5 @@ require 'clock'
 require 'identifier/uuid/controls'
 
 require 'controls/time'
+require 'controls/time/elapsed'
 require 'controls/id'

--- a/lib/controls/time.rb
+++ b/lib/controls/time.rb
@@ -8,8 +8,10 @@ module Controls
     def self.reference; example; end
 
     module ISO8601
-      def self.example
-        Clock::UTC.iso8601(Raw.example)
+      def self.example(time=nil)
+        time ||= Raw.example
+
+        Clock::UTC.iso8601 time
       end
     end
 

--- a/lib/controls/time/elapsed.rb
+++ b/lib/controls/time/elapsed.rb
@@ -1,0 +1,27 @@
+module Controls
+  module Time
+    module Elapsed
+      def self.example(units, reference: nil, precision: nil)
+        reference ||= Time.example
+        reference = Clock.parse reference if reference.is_a? String
+
+        units_per_second = self.units_per_second(precision: precision)
+        elapsed_seconds = Rational(units, units_per_second)
+
+        elapsed_time = reference + elapsed_seconds
+
+        ISO8601.example elapsed_time
+      end
+
+      def self.reference(precision: nil)
+        example 0, precision: precision
+      end
+
+      def self.units_per_second(precision: nil)
+        precision ||= Clock::ISO8601::Defaults.precision
+
+        10 ** precision
+      end
+    end
+  end
+end


### PR DESCRIPTION
These controls are for getting times in iso8601 format that are a known offset from the reference time (e.g. `Controls::Time.reference`). For instance, you might want to test whether or not a billing cycle has finished. This allows for elapsed time windows to be controlled at exactly the level of precision desired. For instance, if you are working with Time objects that were deserialized from an iso8601 string that recorded three numbers after the decimal place (the common case), the unit of increment is 1 millisecond.

Usage:

```ruby
# Two units ahead of the reference time. Two moments have elapsed since the reference time.
Controls::Time::Elapsed.example 2

# Three units behind the reference time
Controls::Time::Elapsed.example -3

# Varying the precision to 5 places after the decimal instead of 3 (the default used is the precision we use when storing ISO8601 dates; that's generally going to be the maximum precision when working with Time objects)
Controls::Time::Elapsed.example 1, precision: 5

# Varying the reference time
Controls::Time::Elapsed.example 1, reference: Time.now
```